### PR TITLE
avoid breaking change in new Rust versions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ fn parse_selection(lines: Option<&str>) -> Option<(usize, usize)> {
         Some(s) => {
             let ns = s.split('-').map(|n| n.parse().unwrap()).collect::<Vec<_>>();
             let start = ns.get(0).expect("Problem parsing selection number");
-            let end = ns.get(1).unwrap_or(&start);
+            let end = ns.get(1).unwrap_or(start);
 
             Some((*start,  *end))
         }


### PR DESCRIPTION
Your crate will unfortunately stop compiling due to changes to compiler internals in https://github.com/rust-lang/rust/pull/119989.

The affected pattern is the following
```rust
fn parse_selection(lines: Option<&str>) -> Option<(usize, usize)> {
    match lines {
        None => None,
        Some(s) => {
            let ns = s.split('-').map(|n| n.parse().unwrap()).collect::<Vec<_>>();
            let start = ns.get(0).expect("Problem parsing selection number");
            let end = ns.get(1).unwrap_or(&start);
            // Fixed by changing this to `unwrap_or(start);`

            // This equates `&start` with `ns.get(1)`, as `start` and `ns.get(1)`
            // share a subtype, unifying the types `&type_of(start)` with `type_of(ns.get(1))`
            // cannot succeed and previously related in an eager "occurs check" failure.
            // This eager failure caused us to add an auto-deref step to `&start`.
            // As this eager failure got removed, we now have to manually add this deref
            // here to avoid an error.

            Some((*start,  *end))
        }
    }
}
```
for more details see https://github.com/rust-lang/rust/pull/119989#issuecomment-1912103911

I apologize for the inconvenience. 